### PR TITLE
Update ViewLog.js

### DIFF
--- a/src/ViewLog.js
+++ b/src/ViewLog.js
@@ -48,7 +48,7 @@ class Log extends React.Component {
 
   render() {
     return (
-      <div style={{"height":"100%"}}>
+      <div style={{"height":"800px"}}>
         <LazyLog text={this.state.logs} />
       </div >
     )


### PR DESCRIPTION
It happens because of LazyLog can't working with flexible parent container 

Fix problem https://github.com/tiburon-security/jupyterlab_scheduler/issues/6